### PR TITLE
Fixed rendering of the "scatterplot" hyperlink

### DIFF
--- a/graph/bubble.Rmd
+++ b/graph/bubble.Rmd
@@ -31,7 +31,7 @@ output:
 # Definition {#definition}
 ***
 
-A `bubble plot is a [scatterplot](http://www.data-to-viz.com/graph/scatter.html) where a `third dimension` is added: the value of an additional numeric variable is represented through the `size` of the dots.
+A `bubble plot` is a [scatterplot](http://www.data-to-viz.com/graph/scatter.html) where a `third dimension` is added: the value of an additional numeric variable is represented through the `size` of the dots.
 
 You need 3 numerical variables as input: one is represented by the X axis, one by the Y axis, and one by the dot size.
 


### PR DESCRIPTION
Looks like it had a misplaced back-tick (`) which caused the hyper link to not render.  It also threw off the styling of other text in that paragraph.

![image](https://user-images.githubusercontent.com/7502365/44357716-c6084500-a480-11e8-980b-5a8099db129c.png)
