### PR TITLE
mcs edits to error_bar.Rmd

### DIFF
--- a/caveat/error_bar.Rmd
+++ b/caveat/error_bar.Rmd
@@ -60,7 +60,7 @@ In the graphic above 5 groups are reported. The bar heights represent their mean
 #Error bars hide information
 ***
 
-The first issue with error bars is that they hide information. Here is a figure from a [paper in PLOS Biology](http://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1002128). It illustrates that the full data may suggest different conclusions than the summary statistics. The same barplot with error bar (left) can represent several situations. Both groups can have the same kind of distribution (`B`), one group can have outliers (`C`), one group can have a bimodal distribution (`D`), or groups can have unequal sample sizes:
+The first issue with error bars is that they hide information. Here is a figure from a [paper in PLOS Biology](http://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1002128). It illustrates that the full data may suggest different conclusions than the summary statistics. The same barplot with error bars (left) can represent several situations. Both groups can have the same kind of distribution (`B`), one group can have outliers (`C`), one group can have a bimodal distribution (`D`), or groups can have unequal sample sizes:
 
 
 <br>
@@ -84,7 +84,7 @@ Thus, the same barplot with error bars can in fact tell very different stories, 
 
 #What is an error bar?
 ***
-The second issue with error bars is that they are used to show `different metrics`, and it is not always clear which one is being shown. Three different types of values are commonly used for error bars, sometimes giving very different results (see further). Here is an overview of their definition and how to calculate them on a simple vector in R. 
+The second issue with error bars is that they are used to show `different metrics`, and it is not always clear which one is being shown. Three different types of values are commonly used for error bars, sometimes giving very different results. Here is an overview of their definitions and how to calculate them on a simple vector in R. 
 
 - [Standard Deviation](https://en.wikipedia.org/wiki/Standard_deviation) (SD) represents the amount of  dispersion of the variable. Calculated as the root square of the variance
 ```{r, eval=FALSE}
@@ -92,12 +92,12 @@ sd <- sd(vec)
 sd <- sqrt(var(vec))
 ```
 
-- [Standard Error](https://en.wikipedia.org/wiki/Standard_error) (SE). It is the standard deviation of the vector sampling distribution. Calculated as the SD divided by the square root of the sample size. By construction, SE is smaller than SD. With a very big sample size, SE tends toward 0.
+- [Standard Error](https://en.wikipedia.org/wiki/Standard_error) (SE) is the standard deviation of the *mean* of the variable, calculated as the SD divided by the square root of the sample size. By construction, the SE is smaller than the SD. With a very large sample size, the SE tends toward 0.
 ```{r, eval=FALSE}
 se = sd(vec) / sqrt(length(vec))
 ```
 
-- [Confidence Interval](https://en.wikipedia.org/wiki/Confidence_interval) (CI). This interval is defined so that there is a specified probability that a value lies within it. It is calculated as t * SE. Where t is the value of the [Student’s t-distribution](https://en.wikipedia.org/wiki/Student%27s_t-distribution) for a specific alpha. Its value is often rounded to 1.96 (its value with a big sample size). If the sample size is huge or the distribution not normal, it is better to calculate the CI using the bootstrap method, however.
+- A [Confidence Interval](https://en.wikipedia.org/wiki/Confidence_interval) (CI) is defined so that there is a specified probability that a value lies within it. It is calculated as t * SE where t is the value of the [Student’s t-distribution](https://en.wikipedia.org/wiki/Student%27s_t-distribution) for a specific alpha. Its value is often rounded to 1.96 (its value with a large sample size). If the sample size is huge or the distribution not normal, it is better to calculate the CI using the bootstrap method, however.
 ```{r, eval=FALSE}
 alpha=0.05
 t=qt((1-alpha)/2 + .5, length(vec)-1)   # tend to 1.96 if sample size is big enough
@@ -106,7 +106,7 @@ CI=t*se
 
 <br>
 
-Here is an application of these 3 metrics to the famous [Iris dataset](https://stat.ethz.ch/R-manual/R-devel/library/datasets/html/iris.html). It shows the average sepal length of three species of Iris. The variation around the average length is represented using the error bar.
+Here is an application of these 3 metrics to the famous [Iris dataset](https://stat.ethz.ch/R-manual/R-devel/library/datasets/html/iris.html). It shows the average sepal length of three species of Iris. The variation around the average length is represented using error bars.
 
 ```{r, warning=FALSE, message=FALSE, fig.align="center", fig.width=10, fig.height=4}
 # Data
@@ -171,7 +171,7 @@ It is quite obvious that the 3 metrics report very different visualizations and 
 #Workaround
 ***
 
-It is better to avoid error bars as much as you can. Of course it is not possible if you only have summary statistics. But if you know the individual data points, show them. Several workarounds are possible. The [boxplot with jitter](http://www.data-to-viz.com/caveat/boxplot.html) is a good one for a relatively small amount of data. The [violin plot](https://www.data-to-viz.com/graph/violin.html) is another possibility if you have a big sample size to display.
+It is better to avoid error bars as much as you can. Of course it is not possible if you only have summary statistics. But if you know the individual data points, show them. Several workarounds are possible. The [boxplot with jitter](http://www.data-to-viz.com/caveat/boxplot.html) is a good one for a relatively small amount of data. The [violin plot](https://www.data-to-viz.com/graph/violin.html) is another possibility if you have a large sample size to display.
   
 ```{r, warning=FALSE, message=FALSE, fig.align="center", fig.width=10}
 data %>%
@@ -193,13 +193,13 @@ data %>%
 ***
 
 - Weissgerber et al. 2015, *Beyond Bar and Line Graphs: Time for a New Data Presentation Paradigm*. [link](http://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1002128)
-- Doing boxplots in [R](https://www.r-graph-gallery.com/boxplot/) and [Python](https://python-graph-gallery.com/boxplot/)
-- Doing violin plots in [R](https://www.r-graph-gallery.com/violin/) and [Python](https://python-graph-gallery.com/violin/)
+- Making boxplots in [R](https://www.r-graph-gallery.com/boxplot/) and [Python](https://python-graph-gallery.com/boxplot/)
+- Making violin plots in [R](https://www.r-graph-gallery.com/violin/) and [Python](https://python-graph-gallery.com/violin/)
 
 
 #Comments
 ***
-Any thoughts on this? Found any mistake? Disagree? Please drop me a word on [twitter](https://twitter.com/R_Graph_Gallery) or in the comment section below:
+Any thoughts on this? Found any mistakes? Disagree? Please drop me a word on [twitter](https://twitter.com/R_Graph_Gallery) or in the comment section below:
 <br>
 
 


### PR DESCRIPTION
There is lots of great stuff in “error_bar.Rmd”, but quite a bit of it is more about statistics in general than the specific issue of error bars, and one cannot teach statistics in a few paragraphs.  For example:

- “Error bars give a general idea of how precise a measurement is [_this part is true_], or conversely, how far from the reported value the true (error free) value might be [_this part is less true, since bias is not addressed--I would leave this 2nd part off..._]”

- Regarding the “Error bars hide information” section—the real issue is that summary statistics can hide information not just error bars.  For a bimodal distribution, the mean is not a good summary measure…

- The whole discussion of difference in SD, SE and CI is great, and part of a basic statistics course…

I don’t agree that “It is better to avoid error bars as much as you can”—for presentation of bar charts to many audiences for many purposes the violin plot or boxplot with jitter is just too much for them to interpret, and appropriately labeled error bars are often way better than not including them at all.

Also, I was going to review the dual_axis.Rmd, but I couldn't find it rendered.  The image below (mistakenly I think?) links to https://blog.datawrapper.de/dualaxis/ not to your good information.
![dual](https://user-images.githubusercontent.com/19944056/51078980-e628e280-1673-11e9-8fa0-68e8023177b6.JPG)


Sorry I have slowed down on these reviews...I will get to all pages at some point! 

Happy New Year!