### PR TITLE
Link to violin plot in R broken

### DIFF
--- a/graph/violin.Rmd
+++ b/graph/violin.Rmd
@@ -218,7 +218,7 @@ data %>%
 The [R](https://www.r-graph-gallery.com) and [Python](https://www.python-graph-gallery.com) graph galleries are 2 websites providing hundreds of chart example, always providing the reproducible code. Click the button below to see how to build the chart you need with your favorite programing language.
 
 <p>
-<a href="https://www.r-graph-gallery.com/violin-plot/" class="btn btn-primary">R graph gallery</a>
+<a href="https://www.r-graph-gallery.com/violin/" class="btn btn-primary">R graph gallery</a>
 <a href="https://python-graph-gallery.com/violin-plot/" class="btn btn-primary">Python gallery</a>
 </p>
 

--- a/graph/violin.html
+++ b/graph/violin.html
@@ -401,7 +401,7 @@ Show the density of several numeric variables. Use it with a large amount of dat
 <hr />
 <p>The <a href="https://www.r-graph-gallery.com">R</a> and <a href="https://www.python-graph-gallery.com">Python</a> graph galleries are 2 websites providing hundreds of chart example, always providing the reproducible code. Click the button below to see how to build the chart you need with your favorite programing language.</p>
 <p>
-<a href="https://www.r-graph-gallery.com/violin-plot/" class="btn btn-primary">R graph gallery</a> <a href="https://python-graph-gallery.com/violin-plot/" class="btn btn-primary">Python gallery</a>
+<a href="https://www.r-graph-gallery.com/violin/" class="btn btn-primary">R graph gallery</a> <a href="https://python-graph-gallery.com/violin-plot/" class="btn btn-primary">Python gallery</a>
 </p>
 <h1 id="comments">Comments</h1>
 <hr />

--- a/index.html
+++ b/index.html
@@ -2858,7 +2858,7 @@
                   <div class="cardtitle">Code</div>
                   <hr>
                   <p>
-                  <a href="https://www.r-graph-gallery.com/violin-plot/" class="btn btn-primary">R graph gallery</a>
+                  <a href="https://www.r-graph-gallery.com/violin/" class="btn btn-primary">R graph gallery</a>
                   <a href="https://python-graph-gallery.com/violin-plot/" class="btn btn-primary">Python gallery</a>
                   <a href="https://www.d3-graph-gallery.com/violin" class="btn btn-primary">D3.js gallery</a>
                   <a href="https://app.flourish.studio/register?affiliate=data-to-viz" class="btn btn-primary" onclick="getOutboundLink('https://app.flourish.studio/register?affiliate=data-to-viz'); return false;">Flourish</a>


### PR DESCRIPTION
Link to violin plots in R is broken. This should correct it.   
I was not sure whether the html page was automatically rebuilt from the Rmd, I modified both. As well as modal in index.html.

You can squash this PR for a cleaner history...